### PR TITLE
feat/acl-list-json

### DIFF
--- a/cmd/listrules.go
+++ b/cmd/listrules.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -38,6 +39,16 @@ var ListAllRulesCmd = &cobra.Command{
 		data, err := ioutil.ReadAll(rsp.Body)
 		if err != nil {
 			return err
+		}
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+		if jsonOutput {
+			var prettyJSON bytes.Buffer
+			err := json.Indent(&prettyJSON, data, "", "  ")
+			if err != nil {
+				return errors.Wrap(err, "failed to prettify JSON")
+			}
+			fmt.Println(prettyJSON.String())
+			return nil
 		}
 		var rules []types.Rule
 		err = json.Unmarshal(data, &rules)
@@ -99,6 +110,16 @@ var ListRuleCmd = &cobra.Command{
 		data, err := ioutil.ReadAll(rsp.Body)
 		if err != nil {
 			return err
+		}
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+		if jsonOutput {
+			var prettyJSON bytes.Buffer
+			err := json.Indent(&prettyJSON, data, "", "  ")
+			if err != nil {
+				return errors.Wrap(err, "failed to prettify JSON")
+			}
+			fmt.Println(prettyJSON.String())
+			return nil
 		}
 		var ruleData serviceRuleData
 		err = json.Unmarshal(data, &ruleData)

--- a/main.go
+++ b/main.go
@@ -79,6 +79,8 @@ func main() {
 
 	cmd.ListRuleCmd.Flags().Bool("show-sync", false, "Show rules latest sync attempt")
 	cmd.ListRuleCmd.Flags().Bool("show-extra-sync", false, "Show rules with latest sync attempt details.")
+	cmd.ListRuleCmd.Flags().Bool("json", false, "Return the raw JSON output instead of the formatted table")
+	cmd.ListAllRulesCmd.Flags().Bool("json", false, "Return the raw JSON output instead of the formatted table")
 	cmd.ListAllRulesCmd.Flags().Bool("show-extra-sync", false, "Show rules with latest sync attempt details.")
 
 	if err := rootCmd.Execute(); err != nil {


### PR DESCRIPTION
## Description:
- Added --json flag to ListRuleCmd and ListAllRulesCmd to allow raw JSON output instead of the default table.
- When --json is used, the output will be prettified JSON.
- This provides flexibility for users who need raw data instead of a formatted table.